### PR TITLE
prefer scp to sftp for ansible file transfers

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,5 @@
 [defaults]
 forks = 50
+    
+[ssh_connection]
+scp_if_ssh=True


### PR DESCRIPTION
Some hosts do not allow sftp connections.